### PR TITLE
feat(streams): refactor streams and buffer usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,44 +1,60 @@
-var PNG = require('png-js');
-var charm = require('charm');
-var x256 = require('x256');
-var buffers = require('buffers');
-var es = require('event-stream');
+var PNG = require("png-js");
+var charm = require("charm");
+var x256 = require("x256");
 
-var Stream = require('stream').Stream;
+var { Duplex } = require("stream");
 
-module.exports = function (opts) {
-    if (!opts) opts = {};
-    if (!opts.cols) opts.cols = 80;
-    
-    var c = charm();
-    var bufs = buffers();
-    
-    var ws = es.writeArray(function (err, bufs) {
-        var data = buffers(bufs).slice();
-        var png = new PNG(data);
-        
-        png.decode(function (pixels) {
-            var dx = png.width / opts.cols;
-            var dy = 2 * dx;
-            
-            for (var y = 0; y < png.height; y += dy) {
-                for (var x = 0; x < png.width; x += dx) {
-                    var i = (Math.floor(y) * png.width + Math.floor(x)) * 4;
-                    
-                    var ix = x256([ pixels[i], pixels[i+1], pixels[i+2] ]);
-                    if (pixels[i+3] > 0) {
-                        c.background(ix).write(' ');
-                    }
-                    else {
-                        c.display('reset').write(' ');
-                    }
-                }
-                c.display('reset').write('\r\n');
-            }
-            
-            c.display('reset').end();
-        });
+class PictureTube extends Duplex {
+  constructor(opts = {}) {
+    super();
+    this.data = [];
+    this.cols = opts.cols || 80;
+
+    this.c = charm();
+
+    this.c.on("data", chunk => {
+      this.push(chunk);
     });
-    
-    return es.duplex(ws, c);
+
+    this.c.on("end", () => {
+      this.emit("end");
+    });
+  }
+
+  _read() {}
+
+  _write(chunk, encoding, callback) {
+    this.data.push(chunk);
+    callback();
+  }
+
+  _final(callback) {
+    var png = new PNG(Buffer.concat(this.data));
+
+    png.decode(pixels => {
+      var dx = png.width / this.cols;
+      var dy = 2 * dx;
+
+      for (var y = 0; y < png.height; y += dy) {
+        for (var x = 0; x < png.width; x += dx) {
+          var i = (Math.floor(y) * png.width + Math.floor(x)) * 4;
+
+          var ix = x256([pixels[i], pixels[i + 1], pixels[i + 2]]);
+          if (pixels[i + 3] > 0) {
+            this.c.background(ix).write(" ");
+          } else {
+            this.c.display("reset").write(" ");
+          }
+        }
+        this.c.display("reset").write("\r\n");
+      }
+
+      this.c.display("reset").end();
+      callback();
+    });
+  }
+}
+
+module.exports = opts => {
+  return new PictureTube(opts);
 };

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ class PictureTube extends Duplex {
     });
 
     this.c.on("end", () => {
-      this.emit("end");
+      this.push(null);
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -8,20 +8,28 @@ class PictureTube extends Duplex {
   constructor(opts = {}) {
     super();
     this.data = [];
-    this.cols = opts.cols || 80;
+    this.cols = opts.cols > 0 ? opts.cols : 80;
 
     this.c = charm();
 
     this.c.on("data", chunk => {
-      this.push(chunk);
+      if (!this.push(chunk)) {
+        this.c.pause();
+      }
     });
 
     this.c.on("end", () => {
       this.push(null);
     });
+
+    this.c.on("error", err => {
+      this.destroy(err);
+    });
   }
 
-  _read() {}
+  _read() {
+    this.c.resume();
+  }
 
   _write(chunk, encoding, callback) {
     this.data.push(chunk);
@@ -29,28 +37,37 @@ class PictureTube extends Duplex {
   }
 
   _final(callback) {
-    var png = new PNG(Buffer.concat(this.data));
+    var png;
+    try {
+      png = new PNG(Buffer.concat(this.data));
+    } catch (err) {
+      return callback(err);
+    }
 
     png.decode(pixels => {
-      var dx = png.width / this.cols;
-      var dy = 2 * dx;
+      try {
+        var dx = png.width / this.cols;
+        var dy = 2 * dx;
 
-      for (var y = 0; y < png.height; y += dy) {
-        for (var x = 0; x < png.width; x += dx) {
-          var i = (Math.floor(y) * png.width + Math.floor(x)) * 4;
+        for (var y = 0; y < png.height; y += dy) {
+          for (var x = 0; x < png.width; x += dx) {
+            var i = (Math.floor(y) * png.width + Math.floor(x)) * 4;
 
-          var ix = x256([pixels[i], pixels[i + 1], pixels[i + 2]]);
-          if (pixels[i + 3] > 0) {
-            this.c.background(ix).write(" ");
-          } else {
-            this.c.display("reset").write(" ");
+            var ix = x256([pixels[i], pixels[i + 1], pixels[i + 2]]);
+            if (pixels[i + 3] > 0) {
+              this.c.background(ix).write(" ");
+            } else {
+              this.c.display("reset").write(" ");
+            }
           }
+          this.c.display("reset").write("\r\n");
         }
-        this.c.display("reset").write("\r\n");
-      }
 
-      this.c.display("reset").end();
-      callback();
+        this.c.display("reset").end();
+        callback();
+      } catch (err) {
+        callback(err);
+      }
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,73 +1,74 @@
 {
-    "name": "picture-tuber",
-    "version": "2.0.0",
-    "lockfileVersion": 1,
-    "requires": true,
-    "dependencies": {
-        "buffers": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
-        },
-        "charm": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
-            "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
-            "requires": {
-                "inherits": "^2.0.1"
-            }
-        },
-        "event-stream": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.10.0.tgz",
-            "integrity": "sha1-O259xZY3FAjQsyhpIOMrP2PzXtU=",
-            "requires": {
-                "optimist": "0.2"
-            },
-            "dependencies": {
-                "optimist": {
-                    "version": "0.2.8",
-                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
-                    "integrity": "sha1-6YGrfiaLRXlIWTtVZ0wJmoFcrDE=",
-                    "requires": {
-                        "wordwrap": ">=0.0.1 <0.1.0"
-                    }
-                }
-            }
-        },
-        "inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "minimist": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-            "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        },
-        "optimist": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-            "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
-            }
-        },
-        "png-js": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
-            "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
-        },
-        "wordwrap": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-        },
-        "x256": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/x256/-/x256-0.0.2.tgz",
-            "integrity": "sha1-ya8Yh296F1gB1WT+cK2egxd4STQ="
-        }
+  "name": "picture-tuber",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "picture-tuber",
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "charm": "~1.0.2",
+        "optimist": "~0.6.1",
+        "png-js": "~1.0.0",
+        "x256": "~0.0.2"
+      },
+      "bin": {
+        "picture-tube": "bin/tube.js"
+      },
+      "devDependencies": {},
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/charm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
+      "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+    },
+    "node_modules/optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dependencies": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/x256": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/x256/-/x256-0.0.2.tgz",
+      "integrity": "sha1-ya8Yh296F1gB1WT+cK2egxd4STQ=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {},
   "engines": {
-    "node": ">=0.4.0"
+    "node": ">=8.0.0"
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Refactoring the original picture-tube code to minimize the use of external modules (`event-stream`, `buffers`) and use built-in Streams and Buffers support in Node.js

Would be happy if someone more experienced with terminal emulation and streams could review this. Perhaps you could help @waldyrious, @J-Cat, @reconbot, @larsonjj ?

Context: this is in follow-up of a blessed-contrib change to use a thinner `picture-tube` package with no vulnerabilities: https://github.com/yaronn/blessed-contrib/pull/162